### PR TITLE
Fixed Hunter Link Issues + More

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,9 +36,11 @@
             <section id="founders" class="section-about founders-section">
                 <div class="founders-content">
                     <h2>Meet Our Founders</h2>
-                    <img src="Images/zzz2.png" class="founder-image">
+                    <img src="Images/zzz2.png" class="founder-image" title="Sam: LEAD DEV">
                     <br>
-                    <img src="Images/zzz.png" class="founder-image">
+                    <img src="Images/zzz.png" class="founder-image" title="Hunter: CO DEV">
+                    <br>
+                    <img src="Images/zzz3.png" class="founder-image" title="Kob: BIG FOR US">
                     <br>
                     <p>
                         Our founders are some sloppy mouth MAGNETS

--- a/contact.html
+++ b/contact.html
@@ -27,12 +27,19 @@
                 <br>
                 <a href="https://www.linkedin.com/in/samuel-buckler-5ba7022b0/">LinkedIn</a>
 
+                <br>
                 <p><b>CO DEV:</b></p>
                 <p>hunter.baker.b@gmail.com</p>
-                <a href="github.com/hutnerr">Github</a>
+                <a href="https://github.com/hutnerr">Github</a>
                 <br>
-                <a href="linkedin.com/in/hunter-b-baker">LinkedIn</a>
-
+                <a href="https://www.linkedin.com/in/hunter-b-baker">LinkedIn</a>
+                
+                <br>
+                <p><strong>BIG FOR US:</strong></p>
+                <p>jayfeather874@gmail.com</p>
+                <a = href="https://github.com/Koborooski">Github</a>
+                <br>
+                <a = href="https://www.linkedin.com/in/koborooski/">LinkedIn</a>
             </section>
         </main>
     </div>


### PR DESCRIPTION
"Contact" page now correctly links to Hunters GitHub and LinkedIn page.

Added text titles to the images on the "About" page.

May or may not have added something that is big for us.